### PR TITLE
Add support for chrono::DateTime<TZ>

### DIFF
--- a/opg/src/lib.rs
+++ b/opg/src/lib.rs
@@ -146,7 +146,36 @@ impl OpgModel for uuid::Uuid {
 impl OpgModel for chrono::NaiveDateTime {
     fn get_schema(_: &mut Components) -> Model {
         Model {
-            description: Some("Datetime".to_owned()),
+            description: Some("Datetime without timezone".to_owned()),
+            data: ModelData::Single(ModelType {
+                nullable: false,
+                type_description: ModelTypeDescription::String(ModelString {
+                    variants: None,
+                    data: ModelSimple {
+                        format: Some("date".to_owned()),
+                        example: Some("2020-06-26T14:04:20.730045106".to_owned()),
+                    },
+                }),
+            }),
+        }
+    }
+
+    #[inline]
+    fn type_name() -> Option<&'static str> {
+        None
+    }
+
+    #[inline]
+    fn select_reference(cx: &mut Components, _: bool, params: &ContextParams) -> ModelReference {
+        ModelReference::Inline(Self::get_schema(cx).apply_params(params))
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl OpgModel for chrono::DateTime<chrono::Utc> {
+    fn get_schema(_: &mut Components) -> Model {
+        Model {
+            description: Some("Datetime with timezone".to_owned()),
             data: ModelData::Single(ModelType {
                 nullable: false,
                 type_description: ModelTypeDescription::String(ModelString {

--- a/opg/src/lib.rs
+++ b/opg/src/lib.rs
@@ -172,7 +172,7 @@ impl OpgModel for chrono::NaiveDateTime {
 }
 
 #[cfg(feature = "chrono")]
-impl OpgModel for chrono::DateTime<chrono::Utc> {
+impl<TZ: chrono::TimeZone> OpgModel for chrono::DateTime<TZ> {
     fn get_schema(_: &mut Components) -> Model {
         Model {
             description: Some("Datetime with timezone".to_owned()),


### PR DESCRIPTION
This PR adds support for the [`DateTime<TZ>`] object for chrono], as `NaiveDateTime` loses timezone information.

Signed-off-by: Matteo Joliveau <matteojoliveau@gmail.com>

[`DateTime<TZ>`]: https://docs.rs/chrono/latest/chrono/struct.DateTime.html