### PR TITLE
Make OpgModel::type_name() return Cow instead

### DIFF
--- a/opg/src/lib.rs
+++ b/opg/src/lib.rs
@@ -1,9 +1,11 @@
-pub mod macros;
-pub mod models;
+use std::borrow::Cow;
 
 pub use macros::*;
 pub use models::*;
 pub use opg_derive::OpgModel;
+
+pub mod macros;
+pub mod models;
 
 pub const OPENAPI_VERSION: &str = "3.0.3";
 pub const SCHEMA_REFERENCE_PREFIX: &str = "#/components/schemas/";
@@ -103,7 +105,7 @@ impl OpgModel for () {
     }
 
     #[inline]
-    fn type_name() -> Option<&'static str> {
+    fn type_name() -> Option<Cow<'static, str>> {
         None
     }
 
@@ -132,7 +134,7 @@ impl OpgModel for uuid::Uuid {
     }
 
     #[inline]
-    fn type_name() -> Option<&'static str> {
+    fn type_name() -> Option<Cow<'static, str>> {
         None
     }
 
@@ -161,7 +163,7 @@ impl OpgModel for chrono::NaiveDateTime {
     }
 
     #[inline]
-    fn type_name() -> Option<&'static str> {
+    fn type_name() -> Option<Cow<'static, str>> {
         None
     }
 
@@ -190,7 +192,7 @@ impl<TZ: chrono::TimeZone> OpgModel for chrono::DateTime<TZ> {
     }
 
     #[inline]
-    fn type_name() -> Option<&'static str> {
+    fn type_name() -> Option<Cow<'static, str>> {
         None
     }
 

--- a/opg/src/macros.rs
+++ b/opg/src/macros.rs
@@ -177,7 +177,7 @@ macro_rules! impl_opg_model (
             }
 
             #[inline]
-            fn type_name() -> Option<&'static str> {
+            fn type_name() -> Option<std::borrow::Cow<'static, str>> {
                 <T as $crate::OpgModel>::type_name()
             }
         }
@@ -193,7 +193,7 @@ macro_rules! impl_opg_model (
             }
 
             #[inline]
-            fn type_name() -> Option<&'static str> {
+            fn type_name() -> Option<std::borrow::Cow<'static, str>> {
                 <T as $crate::OpgModel>::type_name()
             }
         }
@@ -225,7 +225,7 @@ macro_rules! impl_opg_model (
             }
 
             #[inline]
-            fn type_name() -> Option<&'static str> {
+            fn type_name() -> Option<std::borrow::Cow<'static, str>> {
                 None
             }
         }
@@ -255,7 +255,7 @@ macro_rules! impl_opg_model (
             }
 
             #[inline]
-            fn type_name() -> Option<&'static str> {
+            fn type_name() -> Option<std::borrow::Cow<'static, str>> {
                 None
             }
         }
@@ -286,7 +286,7 @@ macro_rules! impl_opg_model (
             }
 
             #[inline]
-            fn type_name() -> Option<&'static str> {
+            fn type_name() -> Option<std::borrow::Cow<'static, str>> {
                 None
             }
         }
@@ -301,7 +301,7 @@ macro_rules! impl_opg_model (
             }
 
             #[inline]
-            fn type_name() -> Option<&'static str> {
+            fn type_name() -> Option<std::borrow::Cow<'static, str>> {
                 <T as $crate::OpgModel>::type_name()
             }
         }
@@ -321,7 +321,7 @@ macro_rules! impl_opg_model (
             }
 
             #[inline]
-            fn type_name() -> Option<&'static str> {
+            fn type_name() -> Option<std::borrow::Cow<'static, str>> {
                 None
             }
         }

--- a/opg/src/models.rs
+++ b/opg/src/models.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{btree_map::Entry, BTreeMap};
 use std::fmt::Write;
 
@@ -577,7 +578,7 @@ pub trait OpgModel {
     fn get_schema(cx: &mut Components) -> Model;
 
     /// Get name of this type
-    fn type_name() -> Option<&'static str>;
+    fn type_name() -> Option<Cow<'static, str>>;
 
     /// Get schema for this type with context parameters applied
     fn get_schema_with_params(cx: &mut Components, params: &ContextParams) -> Model {
@@ -592,7 +593,7 @@ pub trait OpgModel {
         params: &ContextParams,
     ) -> ModelReference {
         match Self::type_name() {
-            Some(link) if !inline => ModelReference::Link(link.to_owned()),
+            Some(link) if !inline => ModelReference::Link(link.into_owned()),
             _ => ModelReference::Inline(Self::get_schema(cx).apply_params(params)),
         }
     }

--- a/opg_derive/src/opg.rs
+++ b/opg_derive/src/opg.rs
@@ -779,7 +779,7 @@ fn implement_type(
     let inline = if inline {
         quote! {
             #[inline]
-            fn type_name() -> Option<&'static str> {
+            fn type_name() -> Option<std::borrow::Cow<'static, str>> {
                 None
             }
 
@@ -791,8 +791,8 @@ fn implement_type(
     } else {
         quote! {
             #[inline]
-            fn type_name() -> Option<&'static str> {
-                Some(stringify!(#type_name))
+            fn type_name() -> Option<std::borrow::Cow<'static, str>> {
+                Some(stringify!(#type_name).into())
             }
         }
     };

--- a/test_suite/tests/api.rs
+++ b/test_suite/tests/api.rs
@@ -1,6 +1,6 @@
 #[allow(dead_code)]
 mod tests {
-    
+
     use opg::*;
     use serde::{Deserialize, Serialize};
 

--- a/test_suite/tests/api.rs
+++ b/test_suite/tests/api.rs
@@ -1,5 +1,6 @@
 #[allow(dead_code)]
 mod tests {
+    
     use opg::*;
     use serde::{Deserialize, Serialize};
 

--- a/test_suite/tests/models.rs
+++ b/test_suite/tests/models.rs
@@ -1,5 +1,6 @@
 #[allow(dead_code)]
 mod tests {
+    
     use opg::{Components, OpgModel};
     use serde::Serialize;
 

--- a/test_suite/tests/models.rs
+++ b/test_suite/tests/models.rs
@@ -1,6 +1,6 @@
 #[allow(dead_code)]
 mod tests {
-    
+
     use opg::{Components, OpgModel};
     use serde::Serialize;
 

--- a/test_suite/tests/repr.rs
+++ b/test_suite/tests/repr.rs
@@ -1,6 +1,6 @@
 #[allow(dead_code)]
 mod tests {
-    
+
     use opg::*;
     use serde_repr::Serialize_repr;
 

--- a/test_suite/tests/repr.rs
+++ b/test_suite/tests/repr.rs
@@ -1,5 +1,6 @@
 #[allow(dead_code)]
 mod tests {
+    
     use opg::*;
     use serde_repr::Serialize_repr;
 


### PR DESCRIPTION
I'm opening this as a draft to discuss it.

This change allow for dynamic type name generation without forcing an allocation when this is not needed.
Before this commit there was no way to return a dynamic type name
because the return type needed to be a statically allocated string. This
didn't allow to have generic structs with generated names. Consider the
following struct that represent a single page over a larger collection
of items:

```rust
struct Page<T> {
  items: Vec<T>,
}
```

We want its OpenAPI type to be dependent on T, so for example
`Page<User>` will have the type name `UserPage`.

Making `type_name()` return a `Cow<'static, str>` allows to implement it
like so:

```rust
fn type_name() -> Option<Cow<'static, str>> {
  match T::type_name() {
    Some(t) => Some(format!("{}Page", t).into()),
    None => Some("Page".into())
  }
}
```

If instead we wanted to use a static string, we can simply write:

```rust
fn type_name() -> Option<Cow<'static, str>> {
  Some("User".into())
}
```

`Cow<'string, str>` dereferences to `&str` so there is no
difference between using Cow or not for most usecases. To get ownership
of the type name we can simply call `name.into_owned()` and get back a
`String` instance. This will only clone, causing an allocation, if a
static name was returned. In case the `Cow` instead contained a
`String`, no allocation would be performed and the inner value would be
simply moved out of the `Cow`.